### PR TITLE
Fixed package interface

### DIFF
--- a/src/js/components/PackageInterface.js
+++ b/src/js/components/PackageInterface.js
@@ -160,7 +160,7 @@ class RestartPackageVolumes extends React.Component {
             <div class="btn-group mr-2">
               <button type="button" class="btn btn-outline-danger tableAction-button"
                 onClick={this.restartPackageVolumes.bind(this)}
-              >Restart</button>
+              >Restart volumes</button>
             </div>
           </div>
         </div>
@@ -223,6 +223,15 @@ class PackageHeader extends React.Component {
     if (state == 'running') toggleButtonTag = 'Pause'
     if (state == 'exited') toggleButtonTag = 'Start'
 
+    let pauseButton = null
+    if (!this.props.isCORE) {
+      pauseButton = (
+        <button type="button" class="btn btn-outline-secondary tableAction-button"
+          onClick={this.togglePackage.bind(this)}
+        >{toggleButtonTag}</button>
+      )
+    }
+
     return (
       <div>
 
@@ -230,9 +239,7 @@ class PackageHeader extends React.Component {
         <h1 class="h2">{capitalize(this.props.displayName)} settings</h1>
         <div class="btn-toolbar mb-2 mb-md-0">
           <div class="btn-group mr-2">
-            <button type="button" class="btn btn-outline-secondary tableAction-button"
-              onClick={this.togglePackage.bind(this)}
-            >{toggleButtonTag}</button>
+            {pauseButton}
             <button type="button" class="btn btn-outline-danger tableAction-button"
               onClick={this.restartPackage.bind(this)}
             >Restart</button>

--- a/src/js/components/PackageList.js
+++ b/src/js/components/PackageList.js
@@ -33,10 +33,6 @@ class Row extends React.Component {
         <td>{this.props._package.ports}</td>
         <td>
           <div class="btn-group" role="group" aria-label="Basic example">
-            <button type="button" class="btn btn-outline-secondary tableAction-button"
-              id={id}
-              onClick={this.props.togglePackage}
-            >{toggleButtonTag}</button>
             <Link
               class="btn btn-outline-secondary tableAction-button"
               to={'package/'+this.props._package.shortName}


### PR DESCRIPTION
- [x] Don't show the pause option for the cores in the general overview.
- [x] Choose better names for each button, right now there are two "restart" which is confusing